### PR TITLE
#16 feat(blog): 카테고리/태그 목록 UI 개선, 사이드바 글 보기 시 카테고리 펼침·포커스, 기타

### DIFF
--- a/.github/workflows/pr-create.yml
+++ b/.github/workflows/pr-create.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   pr-create:
+    if: false # PR 자동 생성 일시 중지 (다시 켜려면 이 줄 삭제)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/features/blog/BlogCategoryView.tsx
+++ b/features/blog/BlogCategoryView.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { PostListItem } from "./api/getPosts";
+import { FileText, NotebookPen, ChevronsLeftRight } from "lucide-react";
 
 type BlogCategoryViewProps = {
   categoryName: string;
@@ -8,19 +9,69 @@ type BlogCategoryViewProps = {
 
 export function BlogCategoryView({ categoryName, posts }: BlogCategoryViewProps) {
   return (
-    <div className="px-6 py-8 font-sans">
-      <h1 className="text-2xl font-semibold text-foreground">{categoryName}</h1>
-      <p className="mt-1 text-sm text-muted-foreground">해당 카테고리 글 {posts.length}개</p>
-      <ul className="mt-6 list-none space-y-2">
-        {posts.map(({ slug, title }) => (
-          <li key={slug}>
-            <Link href={`/blog/${slug}`} className="text-foreground underline hover:text-muted-foreground">
-              {title}
-            </Link>
-          </li>
-        ))}
-      </ul>
-      {posts.length === 0 && <p className="mt-4 text-muted-foreground">아직 글이 없습니다.</p>}
+    <div className="flex flex-col h-full">
+      <header className="flex flex-row items-center p-[5.5px] px-3 gap-2 border-b">
+        <h1 className="text-lg font-semibold text-foreground">{categoryName}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{posts.length}개의 글</p>
+      </header>
+
+      {posts.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-full">
+          <NotebookPen className="size-10 text-muted-foreground" />
+          <p className="mt-6 text-muted-foreground">아직 글이 없습니다.</p>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-2 gap-4 list-none overflow-y-auto px-10 py-4">
+          {posts.map(({ slug, title, excerpt, created_at, tags }) => (
+            <li
+              key={slug}
+              className="relative border hover:bg-accent hover:translate-y-[-2px] group transition-all duration-300 ease-out rounded-md"
+            >
+              <div className="absolute right-2 top-3 flex items-center justify-center rounded-full w-4 h-4 bg-chart-2/70 pointer-events-none">
+                <ChevronsLeftRight
+                  size={12}
+                  className="text-white opacity-10 transition-opacity duration-200 group-hover:opacity-100"
+                />
+              </div>
+              <Link href={`/blog/${slug}`}>
+                <article className="flex flex-col h-48">
+                  <div className="flex flex-row items-center p-2 bg-secondary rounded-t-md gap-2">
+                    <FileText className="text-muted-foreground" size={16} />
+                    <span className="font-semibold group-hover:bg-accent-foreground group-hover:text-accent rounded-md px-2 transition-all duration-300 ease-out">
+                      {title}
+                    </span>
+                    {created_at != null && (
+                      <time dateTime={created_at} className="text-xs pl-4">
+                        {new Date(created_at).toLocaleDateString("ko-KR")}
+                      </time>
+                    )}
+                  </div>
+                  <div className="p-3 flex flex-col justify-between h-full">
+                    {excerpt != null && excerpt !== "" && (
+                      <p className="line-clamp-2 text-sm text-muted-foreground">
+                        {excerpt.length > 150 ? `${excerpt.slice(0, 150)}…` : excerpt}
+                      </p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                      {tags != null && tags.length > 0 && (
+                        <ul className="flex flex-wrap gap-1.5 pt-2" aria-label="태그">
+                          {tags.map(tag => (
+                            <li key={tag.id}>
+                              <span className="rounded-md border border-border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground">
+                                {tag.name}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/features/blog/actions/savePost.ts
+++ b/features/blog/actions/savePost.ts
@@ -36,7 +36,7 @@ export async function savePost(input: SavePostInput): Promise<SavePostResult> {
 
   const supabase = await createClient();
 
-  const excerptText = excerpt?.trim() || stripHtml(content).slice(0, 200) || "";
+  const excerptText = (excerpt?.trim() || stripHtml(content)).slice(0, 150) || "";
   let slug = slugify(title);
   if (!slug || slug === "untitled") slug = `post-${Date.now()}`;
 


### PR DESCRIPTION
# PR Summary

Feat #16

## 변경 사항

### 1. 블로그 카테고리/태그 목록 UI (BlogCategoryView)

- 목록을 **2열 그리드**로 표시
- 카드 형태: 제목, 요약(최대 150자), 날짜, 태그
- 호버 시 테두리/그림자 스타일 적용
- 요약 없을 때는 표시 생략

### 2. 목록 API (getPosts)

- `getPostsByCategorySlug`, `getPostsByTagSlug` 응답에 **excerpt, created_at, tags** 추가
- `post_tags` ↔ `tags` 조인으로 글별 태그 반환
- `PostListItem` 타입에 위 필드 optional 추가

### 3. 요약(excerpt) 150자 제한 (savePost)

- 저장 시: 사용자 입력·자동 생성 모두 **150자**로 제한
- 표시 시: 150자 초과분은 잘라서 `…` 표시

### 4. 사이드바 – 글 보기 시 카테고리 펼침·포커스 (BlogSidebar)

- `/blog/[slug]` 진입 시 해당 글이 속한 **카테고리 자동 펼침**
- 해당 **카테고리·현재 글** 포커스(강조) 스타일 적용
- pathname으로 글 slug 추출 후, 카테고리별 posts에서 매칭
- 펼침 상태를 파생 값으로 계산하고, 사용자 접기만 `collapsedSlugs` state로 관리 (effect 제거, 린트 대응)

### 5. 기타

- **pr-create** 워크플로 일시 중지 (`if: false`)
