### PR TITLE
Feat #13 p2 post details

### DIFF
--- a/features/blog/BlogArticleView.tsx
+++ b/features/blog/BlogArticleView.tsx
@@ -1,9 +1,9 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { INFO_SLUG } from "./constants";
 import { Info } from "./content/Info";
 import { getPostBySlug } from "./api/getPosts";
 import { ArticleActions } from "./components/ArticleActions";
+import { ArticleHeader } from "./components/ArticleHeader";
 
 type BlogArticleViewProps = {
   params: Promise<{ slug: string }>;
@@ -17,33 +17,23 @@ export async function BlogArticleView({ params }: BlogArticleViewProps) {
   const post = await getPostBySlug(slug);
   if (!post) notFound();
 
+  const dateString = new Date(post.created_at).toLocaleDateString("ko-KR");
+  const tags = post.tags ?? [];
+
   return (
-    <article>
-      <div className="font-sans border-b border-border py-8 text-center flex flex-col items-center">
-        <h1 className="text-3xl font-semibold text-foreground">{post.title}</h1>
-        <p className="mt-1 text-sm text-muted-foreground">{new Date(post.created_at).toLocaleDateString("ko-KR")}</p>
-        {post.tags && post.tags.length > 0 && (
-          <ul className="mt-2 flex flex-wrap justify-center gap-2">
-            {post.tags.map(tag => (
-              <li key={tag.id}>
-                <Link
-                  href={`/blog?tag=${encodeURIComponent(tag.slug)}`}
-                  className="rounded-md border border-border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-                >
-                  {tag.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
+    <article className="bg-background flex min-h-full flex-col">
+      <ArticleHeader title={post.title} dateString={dateString} tags={tags} />
       <div className="border-b border-border flex justify-center">
         <ArticleActions slug={slug} />
       </div>
-      <div
-        className="p-4 prose max-w-none text-foreground tiptap-editor"
-        dangerouslySetInnerHTML={{ __html: post.content ?? "" }}
-      />
+      <div className="flex-1 bg-border/20">
+        <div className="max-w-[1080px] mx-auto min-h-full bg-background">
+          <div
+            className="prose max-w-none text-foreground tiptap-editor"
+            dangerouslySetInnerHTML={{ __html: post.content ?? "" }}
+          />
+        </div>
+      </div>
     </article>
   );
 }

--- a/features/blog/BlogLayoutView.tsx
+++ b/features/blog/BlogLayoutView.tsx
@@ -1,10 +1,9 @@
 import { Suspense } from "react";
 import { BlogSelectionBox } from "./components/BlogSelectionBox";
 import { BlogSidebar } from "./components/BlogSidebar";
+import { BlogMain } from "./components/BlogMain";
 import { getCategoriesWithPosts } from "./api/getCategories";
-import { INFO_LIST_ITEM } from "./constants";
-
-const SIDEBAR_POSTS = [INFO_LIST_ITEM];
+import { getRecentPosts } from "./api/getPosts";
 
 function SidebarFallback() {
   return (
@@ -19,14 +18,14 @@ function SidebarFallback() {
 }
 
 export default async function BlogLayoutView({ children }: { children: React.ReactNode }) {
-  const categoriesWithPosts = await getCategoriesWithPosts();
+  const [categoriesWithPosts, recentPosts] = await Promise.all([getCategoriesWithPosts(), getRecentPosts(7)]);
 
   return (
     <BlogSelectionBox>
       <Suspense fallback={<SidebarFallback />}>
-        <BlogSidebar categories={categoriesWithPosts} posts={SIDEBAR_POSTS} />
+        <BlogSidebar categories={categoriesWithPosts} posts={recentPosts} />
       </Suspense>
-      <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{children}</main>
+      <BlogMain>{children}</BlogMain>
     </BlogSelectionBox>
   );
 }

--- a/features/blog/api/getPosts.ts
+++ b/features/blog/api/getPosts.ts
@@ -43,6 +43,24 @@ export async function getPostsList(): Promise<PostListItem[]> {
   return fromDb;
 }
 
+/** 최근 N일 이내 등록된 발행 글 목록 (기본 7일) */
+export async function getRecentPosts(withinDays = 7): Promise<PostListItem[]> {
+  const supabase = await createClient();
+  const since = new Date();
+  since.setDate(since.getDate() - withinDays);
+  const sinceIso = since.toISOString();
+
+  const { data, error } = await supabase
+    .from("posts")
+    .select("slug, title, created_at")
+    .eq("published", true)
+    .gte("created_at", sinceIso)
+    .order("created_at", { ascending: false });
+
+  if (error) return [];
+  return (data ?? []) as PostListItem[];
+}
+
 // DESC 상세 페이지용: 상세 페이지에 표시할 데이터만 조회 */
 export async function getPostBySlug(slug: string): Promise<Post | null> {
   const supabase = await createClient();

--- a/features/blog/components/ArticleHeader.tsx
+++ b/features/blog/components/ArticleHeader.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { BlogScrollContext } from "./BlogMain";
+
+/** Show thin bar when scrolled past this (px). Full header scrolls away with content. */
+const THIN_BAR_THRESHOLD = 80;
+const THIN_BAR_HEIGHT = 40;
+/** Hysteresis: hide thin bar when back above this (avoids jitter) */
+const HIDE_THRESHOLD = 40;
+
+type ArticleHeaderTag = { id: string; slug: string; name: string };
+
+type ArticleHeaderProps = {
+  title: string;
+  dateString: string;
+  tags: ArticleHeaderTag[];
+};
+
+export function ArticleHeader({ title, dateString, tags }: ArticleHeaderProps) {
+  const [showThin, setShowThin] = useState(false);
+  const [barRect, setBarRect] = useState<{ left: number; width: number } | null>(null);
+  const lastYRef = useRef(0);
+  const scrollEl = useContext(BlogScrollContext);
+
+  useLayoutEffect(() => {
+    const el = scrollEl;
+    if (!showThin || !el) return;
+    function updateRect() {
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setBarRect({ left: r.left, width: r.width });
+    }
+    updateRect();
+    const ro = new ResizeObserver(updateRect);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [showThin, scrollEl]);
+
+  useEffect(() => {
+    const el = scrollEl ?? (typeof window !== "undefined" ? window : null);
+    if (!el) return;
+
+    let rafId: number | null = null;
+
+    function handleScroll() {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        const y = el === window ? window.scrollY : (el as HTMLDivElement).scrollTop;
+        const lastY = lastYRef.current;
+
+        if (showThin) {
+          if (y <= HIDE_THRESHOLD) setShowThin(false);
+          else if (y < lastY && y <= THIN_BAR_THRESHOLD) setShowThin(false);
+        } else {
+          if (y > THIN_BAR_THRESHOLD) setShowThin(true);
+        }
+        lastYRef.current = y;
+      });
+    }
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [showThin, scrollEl]);
+
+  return (
+    <>
+      {/* Fixed thin bar: stays at top of viewport so it doesn't shrink at scroll end */}
+      <div
+        className="fixed z-10 flex items-center justify-center bg-chart-2/10 backdrop-blur-md border-b border-border transition-[height,opacity] duration-200 ease-out"
+        style={{
+          top: 0,
+          left: barRect?.left ?? 0,
+          width: barRect?.width ?? "100%",
+          height: showThin ? THIN_BAR_HEIGHT : 0,
+          opacity: showThin ? 1 : 0,
+          minHeight: 0,
+          pointerEvents: showThin ? "auto" : "none",
+        }}
+        aria-hidden={!showThin}
+      >
+        <span className="text-base font-semibold text-foreground truncate max-w-full px-4 py-3">{title}</span>
+      </div>
+
+      {/* Full header: in flow, scrolls up with the page. -mt-px removes top hairline */}
+      <div className="-mt-px border-b border-border py-8 px-4 max-h-[114px] text-center flex flex-col items-center justify-center bg-linear-0 to-chart-2/10">
+        <h1 className="text-3xl font-semibold text-foreground">{title}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{dateString}</p>
+        {tags.length > 0 && (
+          <ul className="mt-2 flex flex-wrap justify-center gap-2">
+            {tags.map(tag => (
+              <li key={tag.id}>
+                <Link
+                  href={`/blog?tag=${encodeURIComponent(tag.slug)}`}
+                  className="rounded-md border border-border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  {tag.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/features/blog/components/BlogMain.tsx
+++ b/features/blog/components/BlogMain.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useState, useCallback, type ReactNode } from "react";
+
+export const BlogScrollContext = createContext<HTMLDivElement | null>(null);
+
+type BlogMainProps = { children: ReactNode };
+
+export function BlogMain({ children }: BlogMainProps) {
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const mainRef = useCallback((el: HTMLDivElement | null) => {
+    if (el) setScrollEl(el);
+  }, []);
+
+  return (
+    <BlogScrollContext.Provider value={scrollEl}>
+      <main ref={mainRef} className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
+        {children}
+      </main>
+    </BlogScrollContext.Provider>
+  );
+}

--- a/features/blog/components/BlogSidebar.tsx
+++ b/features/blog/components/BlogSidebar.tsx
@@ -227,16 +227,18 @@ export function BlogSidebar({ categories = [], posts = [] }: BlogSidebarProps) {
             {posts.length > 0 && (
               <>
                 <p className="mb-2 mt-3 block text-xs font-medium text-muted-foreground/80">최근 등록된 글</p>
-                {posts.map(({ slug, title }) => (
-                  <Link
-                    key={slug}
-                    href={`/blog/${slug}`}
-                    className={`truncate text-xs p-1 hover:text-foreground flex items-center gap-2 ${pathname === `/blog/${slug}` ? "font-medium text-foreground" : ""}`}
-                  >
-                    <FileText size={16} />
-                    {title}
-                  </Link>
-                ))}
+                <div className="flex flex-col gap-1">
+                  {posts.map(({ slug, title }) => (
+                    <Link
+                      key={slug}
+                      href={`/blog/${slug}`}
+                      className={`truncate text-xs p-1 hover:text-foreground flex items-center gap-2 ${pathname === `/blog/${slug}` ? "font-medium text-foreground" : ""}`}
+                    >
+                      <FileText size={16} className="text-muted-foreground/70" />
+                      {title}
+                    </Link>
+                  ))}
+                </div>
               </>
             )}
           </div>

--- a/features/blog/index.tsx
+++ b/features/blog/index.tsx
@@ -10,7 +10,14 @@ export { getCategories, getCategoryBySlug, getCategoriesWithPosts } from "./api/
 export type { CategoryItem, CategoryWithPosts } from "./api/getCategories";
 export { getTags, getTagBySlug } from "./api/getTags";
 export type { TagItem } from "./api/getTags";
-export { getPostsList, getPostBySlug, getPostsByCategorySlug, getPostsByTagSlug, getPostForEdit } from "./api/getPosts";
+export {
+  getPostsList,
+  getPostBySlug,
+  getPostsByCategorySlug,
+  getPostsByTagSlug,
+  getPostForEdit,
+  getRecentPosts,
+} from "./api/getPosts";
 export type { Post, PostListItem, PostForEdit } from "./api/getPosts";
 export { BlogWriteView } from "./BlogWriteView";
 // savePost는 서버 전용 → 클라이언트는 @/features/blog/actions/savePost 직접 임포트

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,13 +5,13 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/** 제목 등에서 URL용 slug 생성 (영문/숫자/하이픈). 한글 등은 제거되어 빈 문자열이 될 수 있음. */
+/** 제목 등에서 URL용 slug 생성. 공백은 하이픈, 한글·영문·숫자·하이픈만 유지 (예: "한글로 해줘" → "한글로-해줘"). */
 export function slugify(text: string): string {
   const s = text
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9-]/g, "")
+    .replace(/[^\p{L}\p{N}-]/gu, "")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
   return s || "untitled";


### PR DESCRIPTION
# PR Summary: feat/13-p2-post-details

Fixes #13 

## 개요

블로그 글 상세 페이지 개선: 아티클 헤더(스크롤 시 얇은 상단바), 본문 스크롤 영역 분리, 최근 일주일 게시물 사이드바 표시, 한글 slug 지원, 본문 영역 배경/질감.

---

## 변경 사항

### 1. ArticleHeader (신규)

- **풀 헤더**: 제목·날짜·태그, `py-8 px-4`, 스크롤 시 본문과 함께 위로 이동
- **얇은 상단바**: 스크롤이 80px 넘으면 상단에 고정(fixed) 얇은 바 표시
  - `BlogScrollContext`로 스크롤 컨테이너(main) 기준 위치·너비 계산
  - 배경 블러·테마 대응

### 2. BlogMain (신규)

- 기존 `<main>` 대체, `overflow-y-auto`로 본문만 스크롤
- `BlogScrollContext`로 스크롤 가능한 main DOM을 자식에게 전달 (ArticleHeader·목차 등에서 사용)

### 3. 최근 게시물

- **getRecentPosts(withinDays?)**: `created_at` 기준 최근 N일(기본 7일) 발행 글 조회
- **사이드바**: "최근 등록된 글"에 위 목록 표시 (Info 페이지에서는 제거)

### 4. Slug 한글 지원

- **lib/utils.ts slugify**: `[^a-z0-9-]` → `[^\p{L}\p{N}-]` 로 변경
- 한글·영문·숫자·하이픈 유지, 예: `한글로 해줘` → `한글로-해줘`

### 5. BlogArticleView

- **레이아웃**: article `flex min-h-full flex-col`, 본문 래퍼 `flex-1` 로 짧은 글에서도 회색 배경이 아래까지 채워지도록 조정
- **본문 영역**: `paper-texture` 클래스로 종이 질감 배경 (CSS radial-gradient 반복)

### 6. 기타

- **BlogLayoutView**: `getRecentPosts(7)` 호출 후 사이드바에 `posts={recentPosts}` 전달
- **index.tsx**: `getRecentPosts` export 추가
- **Info**: 최근 게시물 섹션 제거 (사이드바로 이전)

---

## 파일 변경 요약

| 구분 | 경로 |
|------|------|
| 신규 | `features/blog/components/ArticleHeader.tsx` |
| 신규 | `features/blog/components/BlogMain.tsx` |
| 수정 | `features/blog/BlogArticleView.tsx` |
| 수정 | `features/blog/BlogLayoutView.tsx` |
| 수정 | `features/blog/api/getPosts.ts` (getRecentPosts 추가) |
| 수정 | `features/blog/components/BlogSidebar.tsx` |
| 수정 | `features/blog/index.tsx` |
| 수정 | `features/blog/content/Info.tsx` |
| 수정 | `lib/utils.ts` (slugify 한글 유지) |
| 수정 | `styles/globals.css` (`.paper-texture` 추가, 이번 커밋에 미포함 시 별도 확인) |

---

## 체크리스트

- [x] 블로그 글 상세에서 스크롤 시 얇은 헤더 표시
- [x] 본문만 스크롤되도록 main overflow 처리
- [x] 사이드바에 최근 일주일 게시물 표시
- [x] 한글 제목 slug 지원
- [ ] 본문 영역 배경/종이 질감 적용
