### PR TITLE
Feat#46 subdomain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,8 @@ export function Counter() { ... }
 ## 참고
 
 - **blog**: `getCategories`, `getTags`, `getTagBySlug`, `getPosts*`(목록/상세/카테고리/태그, `thumbnail_url` 포함), 뷰·타입은 `@/features/blog` 배럴로. 이미지 업로드는 `uploadImage`(Server Action), 대표 이미지(썸네일)는 에디터에서 본문 이미지 중 지정 → `posts.thumbnail_url` 저장. `savePost`는 서버 전용이라 **클라이언트에서는** `@/features/blog/actions/savePost` 직접 임포트 (배럴 쓰면 next/headers 등이 클라이언트 번들에 섞여 빌드 에러).
-- **blog URL**: `/blog`만 오면 미들웨어가 `/blog/info`로 리다이렉트. `?tag=`, `?category=` 있으면 리다이렉트 안 함 → `/blog`에서 BlogView가 태그/카테고리 필터 목록 표시. 글 상세는 `/blog/[slug]`, 글 쓰기/수정은 `/blog/write`.
+- **blog URL**: `/blog`만 오면 미들웨어가 `/blog/info`로 리다이렉트. `?tag=`, `?category=` 있으면 리다이렉트 안 함 → `/blog`에서 BlogView가 태그/카테고리 필터 목록 표시. 글 상세는 `/blog/[slug]`, 글 쓰기/수정은 `/blog/write`. **서브도메인** `blog.(host)`에서는 주소창에 `/blog` 없이 `/`, `/info`, `/?category=...` 형태로 동작(미들웨어 rewrite). 상세는 [docs/learn/BLOG-SUBDOMAIN.md](./docs/learn/BLOG-SUBDOMAIN.md).
+- **Header Blog 링크**: 메인 사이트 헤더의 "Blog"는 **env**로 연결. `NEXT_PUBLIC_BLOG_URL`이 있으면 그 URL로, 없으면 개발 시 `http://blog.localhost:3000`, 프로덕션 시 `/blog`로 이동. 로컬/프로덕션 구분은 같은 변수에 환경별로 다른 값을 넣으면 됨.
 - **blog 로그인**: 글 쓰기/수정/삭제는 로그인한 사용자만 가능. Supabase Auth 사용. 비로그인 시 `/blog/write`에서는 에디터 대신 **로그인 페이지**(전체 화면)가 나옴. 수정/삭제 버튼은 로그인한 사용자에게만 글 상세에 노출. 인증 흐름·구조는 [docs/AUTH.md](./docs/AUTH.md) 참고.
 - **글 보기**: 본문은 `tiptap-editor` 클래스로 에디터와 동일 스타일 적용. 글 헤더에 태그 링크(`/blog?tag=slug`) 표시.
 - **에디터**: Tiptap·PublishSidebar·ImageWithBadge·RepresentativeImageContext 등은 여러 기능에서 쓸 수 있는 공용이므로 `components/tiptap/`에 둠.
@@ -108,10 +109,11 @@ export function Counter() { ... }
 
 ## 상세 문서
 
-| 문서                                      | 내용                                               |
-| ----------------------------------------- | -------------------------------------------------- |
-| [ARCHITECTURE.md](./docs/ARCHITECTURE.md) | 폴더 구조, 렌더링 플로우, 네이밍 컨벤션            |
-| [ROUTING.md](./docs/ROUTING.md)           | Next.js App Router, 동적 라우트, Route Group       |
-| [STYLING.md](./docs/STYLING.md)           | 디자인 토큰 정의, 사용 가능한 클래스               |
-| [STATE.md](./docs/STATE.md)               | Global/Scoped Store 패턴, 코드 예시                |
-| [AUTH.md](./docs/AUTH.md)                 | Supabase Auth, 로그인 페이지, 서버/클라이언트 보호 |
+| 문서                                                      | 내용                                                     |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| [ARCHITECTURE.md](./docs/ARCHITECTURE.md)                 | 폴더 구조, 렌더링 플로우, 네이밍 컨벤션                  |
+| [ROUTING.md](./docs/ROUTING.md)                           | Next.js App Router, 동적 라우트, Route Group             |
+| [STYLING.md](./docs/STYLING.md)                           | 디자인 토큰 정의, 사용 가능한 클래스                     |
+| [STATE.md](./docs/STATE.md)                               | Global/Scoped Store 패턴, 코드 예시                      |
+| [AUTH.md](./docs/AUTH.md)                                 | Supabase Auth, 로그인 페이지, 서버/클라이언트 보호       |
+| [learn/BLOG-SUBDOMAIN.md](./docs/learn/BLOG-SUBDOMAIN.md) | 블로그 서브도메인(미들웨어, BlogLink, Header env) 공부용 |

--- a/app/write/page.tsx
+++ b/app/write/page.tsx
@@ -1,7 +1,0 @@
-export default function WritePage() {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background font-sans">
-      <p className="text-muted-foreground">Write — Header/Footer 없음</p>
-    </div>
-  );
-}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,11 +2,13 @@ import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { CursorStrokeText } from "@/components/CursorStrokeText";
 
+const BLOG_HREF = process.env.NEXT_PUBLIC_BLOG_URL ?? "/blog";
+
 export function Header() {
   return (
     <header className="bg-grid-center flex justify-center gap-x-(--grid-pair-width) px-(--grid-edge) select-none">
       <nav className="flex flex-col flex-1 items-end text-sm">
-        <Link href="/blog" className="text-muted-foreground hover:text-foreground">
+        <Link href={BLOG_HREF} className="text-muted-foreground hover:text-foreground">
           Blog
         </Link>
         <Link href="/projects" className="text-muted-foreground hover:text-foreground">

--- a/components/tiptap/Toolbar.jsx
+++ b/components/tiptap/Toolbar.jsx
@@ -119,7 +119,7 @@ export function Toolbar({ editor, representativeImageUrl, onSetThumbnail, onImag
   const currentLink = editor.getAttributes("link").href ?? "";
 
   return (
-    <div className="flex flex-wrap items-center gap-0.5 border-b border-t border-border bg-muted/30 px-1 py-1">
+    <div className="flex flex-wrap items-center gap-0.5 border-b border-t border-border bg-muted/30 px-1 py-[3.1px]">
       {/* 1. Heading / Paragraph */}
       <select
         value={

--- a/components/tiptap/index.jsx
+++ b/components/tiptap/index.jsx
@@ -19,6 +19,9 @@ import { PublishSidebar } from "./PublishSidebar";
 import { savePost } from "@/features/blog/actions/savePost";
 import { uploadImage } from "@/features/blog/actions/uploadImage";
 
+/** 새 글 기본 본문 (빈 문단 여러 개로 최소 높이 확보) */
+const EMPTY_CONTENT = Array(14).fill("<p></p>").join("");
+
 /** @typedef {{ id: string; name: string; slug: string }} CategoryItem */
 /** @typedef {{ id: string; name: string; slug: string }} TagItem */
 /** @typedef {{ id: string; slug: string; title: string; content: string; category_id: string; tag_ids: string[]; published_at: string | null; thumbnail_url?: string | null }} PostForEdit */
@@ -45,7 +48,7 @@ export default function TiptapEditor({ categories = [], tags = [], initialPost =
       Color,
       FontFamily,
     ],
-    content: initialPost?.content ?? "<p>Hello World! 🌎</p>",
+    content: initialPost?.content ?? EMPTY_CONTENT,
     immediatelyRender: false,
     editorProps: {
       attributes: {

--- a/features/blog/BlogCategoryView.tsx
+++ b/features/blog/BlogCategoryView.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import type { PostListItem } from "./api/getPosts";
 import { FileText, NotebookPen, ChevronsLeftRight } from "lucide-react";
 import Image from "next/image";
+import BlogLink from "./components/BlogLink";
 
 type BlogCategoryViewProps = {
   categoryName: string;
@@ -9,7 +9,6 @@ type BlogCategoryViewProps = {
 };
 
 export function BlogCategoryView({ categoryName, posts }: BlogCategoryViewProps) {
-  console.log(posts);
   return (
     <div className="flex flex-col h-full">
       <header className="flex flex-row items-center p-[5.5px] px-3 gap-2 border-b">
@@ -35,7 +34,7 @@ export function BlogCategoryView({ categoryName, posts }: BlogCategoryViewProps)
                   className="text-white opacity-10 transition-opacity duration-200 group-hover:opacity-100"
                 />
               </div>
-              <Link href={`/blog/${encodeURIComponent(slug)}`}>
+              <BlogLink href={`/blog/${encodeURIComponent(slug)}`}>
                 <article className="flex flex-col h-48">
                   <div className="flex flex-row items-center p-2 bg-secondary rounded-t-md gap-2 min-h-0 shrink-0">
                     <FileText className="text-muted-foreground shrink-0" size={16} />
@@ -82,7 +81,7 @@ export function BlogCategoryView({ categoryName, posts }: BlogCategoryViewProps)
                     </div>
                   </div>
                 </article>
-              </Link>
+              </BlogLink>
             </li>
           ))}
         </ul>

--- a/features/blog/components/ArticleHeader.tsx
+++ b/features/blog/components/ArticleHeader.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { BlogScrollContext } from "./BlogMain";
+import BlogLink from "./BlogLink";
 
 /** Show thin bar when scrolled past this (px). Full header scrolls away with content. */
 const THIN_BAR_THRESHOLD = 80;
@@ -95,12 +95,12 @@ export function ArticleHeader({ title, dateString, tags }: ArticleHeaderProps) {
           <ul className="mt-2 flex flex-wrap justify-center gap-2">
             {tags.map(tag => (
               <li key={tag.id}>
-                <Link
-                  href={`/blog?tag=${encodeURIComponent(tag.slug)}`}
+                <BlogLink
+                  href={`/blog/?tag=${encodeURIComponent(tag.slug)}`}
                   className="rounded-md border border-border bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   {tag.name}
-                </Link>
+                </BlogLink>
               </li>
             ))}
           </ul>

--- a/features/blog/components/BlogLink.tsx
+++ b/features/blog/components/BlogLink.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import Link from "next/link";
+
+interface BlogLinkProps {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+// 1. 서버용 스냅샷 (원본 유지)
+const getServerSnapshot = () => false;
+
+// 2. 클라이언트용 스냅샷 (서브도메인 여부 확인)
+const getSnapshot = () => {
+  if (typeof window === "undefined") return false;
+  return window.location.hostname.startsWith("blog.");
+};
+
+// 3. 구독 (도메인은 변하지 않으므로 빈 함수)
+const subscribe = () => () => {};
+
+export default function BlogLink({ href, children, className, style }: BlogLinkProps) {
+  const isBlogSubdomain = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  // BlogLink.tsx 내부 로직 수정
+  let finalHref = href;
+
+  if (isBlogSubdomain && href.startsWith("/blog")) {
+    // 1. '/blog' 바로 뒤의 글자를 확인
+    const afterBlog = href.substring(5); // '/blog'가 5글자이므로 그 이후 추출
+
+    if (afterBlog.startsWith("?") || afterBlog.startsWith("#")) {
+      // '/blog?category=...' 형태일 때 -> '/?category=...'
+      finalHref = "/" + afterBlog;
+    } else if (afterBlog.startsWith("/")) {
+      // '/blog/post-1' 형태일 때 -> '/post-1'
+      finalHref = afterBlog;
+    } else if (afterBlog === "") {
+      // '/blog' 그 자체일 때 -> '/'
+      finalHref = "/";
+    }
+  }
+
+  return (
+    <Link href={finalHref} className={className} style={style}>
+      {children}
+    </Link>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,56 @@
-// middleware.ts (프로젝트 루트)
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-const INFO_SLUG = "info";
+const INFO_SLUG = "info"; // 기존에 사용하시던 슬러그 값
 
 export function middleware(request: NextRequest) {
-  const { pathname, searchParams } = request.nextUrl;
+  const url = request.nextUrl.clone();
+  const { pathname, searchParams } = url;
+  const hostname = request.headers.get("host") || "";
 
-  // 정확히 /blog 이고, category/tag 없으면 /blog/info 로. 목록 필터(?tag=, ?category=) 있으면 리다이렉트 안 함
-  const category = searchParams.get("category")?.trim();
-  const tag = searchParams.get("tag")?.trim();
-  if (pathname === "/blog" && !category && !tag) {
-    const url = request.nextUrl.clone();
-    url.pathname = `/blog/${INFO_SLUG}`;
-    return NextResponse.redirect(url, 307);
+  // 1. 서브도메인 판단 (로컬호스트 포함)
+  const isBlogSubdomain = hostname.startsWith("blog.");
+
+  if (isBlogSubdomain) {
+    // [Case A] 서브도메인으로 접속했을 때 (blog.xxx/...)
+
+    const category = searchParams.get("category")?.trim();
+    const tag = searchParams.get("tag")?.trim();
+
+    if (pathname === "/" && !category && !tag) {
+      return NextResponse.rewrite(new URL(`/blog/${INFO_SLUG}`, request.url));
+    }
+
+    if (pathname === "/" && (category || tag)) {
+      url.pathname = "/blog";
+      return NextResponse.rewrite(url);
+    }
+
+    if (!pathname.startsWith("/blog")) {
+      url.pathname = `/blog${pathname}`;
+      return NextResponse.rewrite(url);
+    }
+  } else {
+    // [Case B] 메인 도메인으로 접속했을 때 (imio.dev/blog)
+
+    // 기존 로직: /blog 접속 시 /blog/info로 리다이렉트
+    const category = searchParams.get("category")?.trim();
+    const tag = searchParams.get("tag")?.trim();
+
+    if (pathname === "/blog" && !category && !tag) {
+      url.pathname = `/blog/${INFO_SLUG}`;
+      return NextResponse.redirect(url, 307);
+    }
   }
 
   return NextResponse.next();
 }
+
+export const config = {
+  matcher: [
+    /*
+     * 정적 파일 및 API 경로를 제외한 모든 경로에서 실행
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -74,6 +74,7 @@
   padding: 0.75rem 1rem;
   outline: none;
   box-shadow: none;
+  caret-color: hsl(var(--chart-2));
 }
 
 .tiptap-editor:focus,


### PR DESCRIPTION
# PR: 블로그 서브도메인 연동

## 요약

메인 도메인(`example.com/blog`)과 서브도메인(`blog.example.com`)에서 같은 블로그를 쓰되, 서브도메인에서는 주소창에 `/blog` 없이 `/`, `/info`, `/?category=...` 형태로 보이도록 연동했습니다.

## 변경 사항

### 미들웨어 (`middleware.ts`)
- **Host**가 `blog.`로 시작하면 서브도메인으로 판별.
- 서브도메인 요청을 **rewrite**로 내부 `/blog`, `/blog/info` 등으로 매핑. 쿼리(`?category`, `?tag`) 유지.
- `_next/static`, `api`, `favicon` 등은 matcher에서 제외해 정적 자원 404 방지.

### BlogLink (`features/blog/components/BlogLink.tsx`) — 신규
- 블로그 **내부** 링크 전용 컴포넌트. 서브도메인일 때 `href`에서 `/blog` 제거.
  - `/blog/info` → `/info`, `/blog?category=study` → `/?category=study`
- `useSyncExternalStore`로 클라이언트에서만 host 기준 변환 (hydration 일치).

### Header (`components/layout/Header.tsx`)
- "Blog" 링크를 **env**로 연결: `NEXT_PUBLIC_BLOG_URL`.
- 없으면 개발 시 `http://blog.localhost:3000`, 프로덕션 시 `/blog`로 이동. 로컬/프로덕션은 같은 변수에 환경별 값 설정.

### BlogSidebar
- **getPostSlugFromPathname**: pathname이 `/blog/slug` 또는 `/slug` 모두 처리, `decodeURIComponent` + **NFC 정규화**로 한글 slug 대응.
- 현재 글 slug 기준 카테고리 펼침·active 스타일을 NFC 정규화된 slug로 비교.

### 기타
- **AGENTS.md**: blog 서브도메인·Header env 설명, `learn/BLOG-SUBDOMAIN.md` 링크 추가.
- `app/write/page.tsx` 삭제.
- BlogCategoryView, ArticleHeader, Tiptap, globals.css 등 연관 수정.

## 환경 변수

| 변수 | 설명 |
|------|------|
| `NEXT_PUBLIC_BLOG_URL` | (선택) 헤더 "Blog" 링크 목적지. 로컬 예: `http://blog.localhost:3000`, 프로덕션 예: `https://blog.도메인.com` |

없으면 개발 시 `http://blog.localhost:3000`, 프로덕션 시 `/blog`로 동작.

## 확인 방법

- **서브도메인**: `http://blog.localhost:3000/`, `http://blog.localhost:3000/info`, `http://blog.localhost:3000/?category=...` 로 접속해 주소창에 `/blog` 없이 표시되는지 확인.
- **메인 도메인**: `http://localhost:3000/blog`, `/blog/info` 등 기존처럼 동작하는지 확인.
- 메인에서 헤더 "Blog" 클릭 시 `NEXT_PUBLIC_BLOG_URL` 또는 기본값으로 이동하는지 확인.

## 문서

- **공부용**: [docs/learn/BLOG-SUBDOMAIN.md](./learn/BLOG-SUBDOMAIN.md) — 미들웨어, BlogLink, Header env, slug/NFC 흐름 정리.

---

**브랜치**: `feat/46-i7-subdomain`

Closes #46 