### PR TITLE
Feat #42 P10 Save post data

### DIFF
--- a/app/blog/write/page.tsx
+++ b/app/blog/write/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { BlogWriteView, getCategories, getTags, getPostForEdit } from "@/features/blog";
+import { BlogWriteView, getCategories, getTags, getPostForEdit, getDraftPosts } from "@/features/blog";
 import { LoginView } from "@/features/auth";
 
 type BlogWritePageProps = {
@@ -17,10 +17,11 @@ export default async function BlogWritePage({ searchParams }: BlogWritePageProps
     return <LoginView slug={slug ?? undefined} returnTo={returnTo ?? undefined} />;
   }
 
-  const [categories, tags, initialPost] = await Promise.all([
+  const [categories, tags, initialPost, drafts] = await Promise.all([
     getCategories(),
     getTags(),
     slug ? getPostForEdit(slug) : Promise.resolve(null),
+    getDraftPosts(),
   ]);
-  return <BlogWriteView categories={categories} tags={tags} initialPost={initialPost ?? undefined} />;
+  return <BlogWriteView categories={categories} tags={tags} initialPost={initialPost ?? undefined} drafts={drafts} />;
 }

--- a/components/tiptap/PublishSidebar.jsx
+++ b/components/tiptap/PublishSidebar.jsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useId } from "react";
-import { X } from "lucide-react";
+import { useState, useId, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -71,6 +70,15 @@ export function PublishSidebar({
     .map(s => s.trim())
     .filter(Boolean);
 
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = e => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
   const handleSave = async published => {
     await onSave({
       categoryId,
@@ -100,17 +108,6 @@ export function PublishSidebar({
         aria-label="발행 설정"
       >
         <div className="flex h-full flex-col">
-          <div className="flex items-center justify-between border-b border-border px-4 py-3">
-            <h2 className="text-base font-semibold">발행</h2>
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-              aria-label="닫기"
-            >
-              <X size={20} />
-            </button>
-          </div>
           <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-4">
             {/* 카테고리 */}
             <div className="space-y-2">

--- a/features/blog/BlogCategoryView.tsx
+++ b/features/blog/BlogCategoryView.tsx
@@ -1,5 +1,5 @@
 import type { PostListItem } from "./api/getPosts";
-import { FileText, NotebookPen, ChevronsLeftRight } from "lucide-react";
+import { FileText, NotebookPen, ChevronsLeftRight, BookDashed } from "lucide-react";
 import Image from "next/image";
 import BlogLink from "./components/BlogLink";
 
@@ -17,12 +17,11 @@ export function BlogCategoryView({ categoryName, posts }: BlogCategoryViewProps)
       </header>
 
       {posts.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-full">
-          <NotebookPen className="size-10 text-muted-foreground" />
-          <p className="mt-6 text-muted-foreground">아직 글이 없습니다.</p>
+        <div className="flex flex-col items-center justify-center h-full bg-accent/30">
+          <BookDashed className="text-muted-foreground/20" size={44} />
         </div>
       ) : (
-        <ul className="min-w-[800px] grid grid-cols-2 gap-4 list-none overflow-y-auto px-10 py-4">
+        <ul className="min-w-[800px] grid grid-cols-2 gap-4 list-none overflow-y-auto px-10 py-4 bg-accent/30">
           {posts.map(({ slug, title, excerpt, created_at, thumbnail_url, tags }) => (
             <li
               key={slug}

--- a/features/blog/BlogWriteView.tsx
+++ b/features/blog/BlogWriteView.tsx
@@ -1,18 +1,19 @@
 "use client";
 
 import Tiptap from "@/components/Tiptap";
-import type { CategoryItem, TagItem, PostForEdit } from "@/features/blog";
+import type { CategoryItem, TagItem, PostForEdit, DraftListItem } from "@/features/blog";
 
 type BlogWriteViewProps = {
   categories: CategoryItem[];
   tags: TagItem[];
   initialPost?: PostForEdit | null;
+  drafts?: DraftListItem[];
 };
 
-export function BlogWriteView({ categories, tags, initialPost }: BlogWriteViewProps) {
+export function BlogWriteView({ categories, tags, initialPost, drafts = [] }: BlogWriteViewProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <Tiptap categories={categories} tags={tags} initialPost={initialPost} />
+      <Tiptap categories={categories} tags={tags} initialPost={initialPost} drafts={drafts} />
     </div>
   );
 }

--- a/features/blog/api/getPosts.ts
+++ b/features/blog/api/getPosts.ts
@@ -86,6 +86,26 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
   return { ...post, tags } as Post;
 }
 
+/** 임시 저장(미발행) 글 목록 - 에디터 드롭다운용 */
+export type DraftListItem = {
+  id: string;
+  slug: string;
+  title: string;
+  updated_at: string;
+};
+
+export async function getDraftPosts(): Promise<DraftListItem[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("posts")
+    .select("id, slug, title, updated_at")
+    .eq("published", false)
+    .order("updated_at", { ascending: false });
+
+  if (error) return [];
+  return (data ?? []) as DraftListItem[];
+}
+
 // DESC 편집 페이지용: slug로 글 조회 (published 무관), category_id·tag_ids 포함 */
 export async function getPostForEdit(slug: string): Promise<PostForEdit | null> {
   const supabase = await createClient();

--- a/features/blog/components/BlogSidebar.tsx
+++ b/features/blog/components/BlogSidebar.tsx
@@ -234,7 +234,7 @@ export function BlogSidebar({ categories = [], posts = [] }: BlogSidebarProps) {
                         </ul>
                       )}
                       {isExpanded && categoryPosts.length === 0 && (
-                        <p className="px-3 py-1.5 pl-5 text-xs text-muted-foreground">아직 글이 없습니다.</p>
+                        <p className="px-3 py-1.5 pl-5 text-xs text-muted-foreground">아직 글이 없어요</p>
                       )}
                     </div>
                   );

--- a/features/blog/index.tsx
+++ b/features/blog/index.tsx
@@ -17,7 +17,8 @@ export {
   getPostsByTagSlug,
   getPostForEdit,
   getRecentPosts,
+  getDraftPosts,
 } from "./api/getPosts";
-export type { Post, PostListItem, PostForEdit } from "./api/getPosts";
+export type { Post, PostListItem, PostForEdit, DraftListItem } from "./api/getPosts";
 export { BlogWriteView } from "./BlogWriteView";
 // savePost는 서버 전용 → 클라이언트는 @/features/blog/actions/savePost 직접 임포트


### PR DESCRIPTION
# PR: 임시저장 목록 드롭다운 + PublishSidebar ESC 닫기

## 요약

글쓰기 화면에서 **임시 저장한 글 목록**을 버튼 하나로 보고 불러올 수 있게 하고, 발행 사이드바는 **ESC**로 닫을 수 있게 했습니다.

## 변경 사항

### 1. 임시저장 글 목록 API

- **파일**: `features/blog/api/getPosts.ts`
- **추가**: `getDraftPosts()` — `published = false` 인 글만 `id`, `slug`, `title`, `updated_at` 조회, `updated_at` 내림차순.
- **타입**: `DraftListItem` export.

### 2. write 페이지 → 에디터로 drafts 전달

- **`app/blog/write/page.tsx`**: `getDraftPosts()` 호출 후 `drafts`를 `BlogWriteView`에 전달.
- **`BlogWriteView`**: `drafts` prop 추가, `Tiptap`에 그대로 전달.
- **`features/blog/index.tsx`**: `getDraftPosts`, `DraftListItem` export 추가.

### 3. 에디터 헤더 — 임시저장(N) 버튼 + 드롭다운

- **파일**: `components/tiptap/index.jsx`
- **버튼**: `임시저장({drafts.length})` + ChevronDown. 임시 저장 글이 없으면 비활성(회색).
- **드롭다운**: 클릭 시 열림. 각 항목에 **제목**(없으면 "제목 없음"), **수정 시각**(로컬 포맷 `ko-KR` short date/time) 표시.
- **동작**: 항목 클릭 시 `/blog/write?slug=해당slug` 로 이동해 해당 글이 로드됨.
- **닫기**: 드롭다운 바깥 클릭 시 닫힘.

### 4. PublishSidebar ESC로 닫기

- **파일**: `components/tiptap/PublishSidebar.jsx`
- **추가**: `open === true` 일 때만 `keydown` 리스너 등록, `Escape` 입력 시 `onClose()` 호출 후 리스너 제거.

## 확인 방법

- **임시저장 드롭다운**: `/blog/write` 에서 임시 저장한 글이 있으면 "임시저장(N)" 버튼 클릭 → 제목·수정 시각 보이는지, 항목 클릭 시 해당 글로 이동하는지 확인.
- **PublishSidebar**: 발행 버튼으로 사이드바 연 뒤 ESC 누르면 닫히는지 확인.

## 수정된 파일

| 파일 | 변경 |
|------|------|
| `features/blog/api/getPosts.ts` | `getDraftPosts`, `DraftListItem` 추가 |
| `features/blog/index.tsx` | export 추가 |
| `app/blog/write/page.tsx` | `getDraftPosts` 호출, `drafts` 전달 |
| `features/blog/BlogWriteView.tsx` | `drafts` prop 추가 |
| `components/tiptap/index.jsx` | drafts 드롭다운 버튼·목록·라우팅 |
| `components/tiptap/PublishSidebar.jsx` | ESC 키로 닫기 |

---

**브랜치**: `feat/42-p10-save-post-data`

Closes #42 