### PR TITLE
feat: resume 페이지 및 resume/blog 서브도메인

### DIFF
--- a/app/resume/layout.tsx
+++ b/app/resume/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import "@/features/resume/styles/resume.css";
+
+export const metadata: Metadata = {
+  title: "Resume | sabuzak",
+  description: "이력서 · 경력증명서",
+};
+
+export default function ResumeLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,0 +1,5 @@
+import { ResumeView } from "@/features/resume";
+
+export default function ResumePage() {
+  return <ResumeView />;
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { CursorStrokeText } from "@/components/CursorStrokeText";
 
 const BLOG_HREF = process.env.NEXT_PUBLIC_BLOG_URL ?? "/blog";
+const RESUME_HREF = process.env.NEXT_PUBLIC_RESUME_URL ?? "/resume";
 
 export function Header() {
   return (
@@ -10,6 +11,9 @@ export function Header() {
       <nav className="flex flex-col flex-1 items-end text-sm">
         <Link href={BLOG_HREF} className="text-muted-foreground hover:text-foreground">
           Blog
+        </Link>
+        <Link href={RESUME_HREF} className="text-muted-foreground hover:text-foreground">
+          Resume
         </Link>
         <Link href="/projects" className="text-muted-foreground hover:text-foreground">
           Projects

--- a/features/resume/ResumeView.tsx
+++ b/features/resume/ResumeView.tsx
@@ -1,0 +1,89 @@
+import { resumeData } from "./data";
+import { Section } from "./components/Section";
+import { ResumeHeader } from "./components/ResumeHeader";
+
+function formatIssueDate(): string {
+  return new Date().toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+export function ResumeView() {
+  const issueDate = formatIssueDate();
+  const { name, email, contact, summary, career, education, skills, certifications } = resumeData;
+
+  return (
+    <div className="resume-page min-h-screen bg-background font-sans text-foreground">
+      <div className="mx-auto max-w-2xl px-6 py-10 md:px-8 md:py-14">
+        <ResumeHeader data={{ name, email, contact }} issueDate={issueDate} />
+
+        {summary ? (
+          <Section title="요약">
+            <p className="text-muted-foreground">{summary}</p>
+          </Section>
+        ) : null}
+
+        {career.length > 0 ? (
+          <Section title="경력">
+            <ul className="space-y-6">
+              {career.map((item, i) => (
+                <li key={i}>
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <span className="font-medium text-foreground">{item.company}</span>
+                    <span className="text-sm text-muted-foreground">{item.period}</span>
+                  </div>
+                  <p className="mt-0.5 text-sm text-muted-foreground">{item.position}</p>
+                  <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-foreground">
+                    {item.duties.map((duty, j) => (
+                      <li key={j}>{duty}</li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          </Section>
+        ) : null}
+
+        {education.length > 0 ? (
+          <Section title="학력">
+            <ul className="space-y-4">
+              {education.map((item, i) => (
+                <li key={i}>
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <span className="font-medium text-foreground">{item.school}</span>
+                    <span className="text-sm text-muted-foreground">{item.period}</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {item.major} · {item.degree}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </Section>
+        ) : null}
+
+        {skills.length > 0 ? (
+          <Section title="기술">
+            <p className="text-sm text-foreground">{skills.join(" · ")}</p>
+          </Section>
+        ) : null}
+
+        {certifications.length > 0 ? (
+          <Section title="자격·인증">
+            <ul className="space-y-2">
+              {certifications.map((item, i) => (
+                <li key={i} className="text-sm text-foreground">
+                  {item.name}
+                  {item.issuer ? ` (${item.issuer})` : ""}
+                  {item.date ? ` · ${item.date}` : ""}
+                </li>
+              ))}
+            </ul>
+          </Section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/features/resume/components/ResumeHeader.tsx
+++ b/features/resume/components/ResumeHeader.tsx
@@ -1,0 +1,24 @@
+import type { ResumeData } from "../data";
+
+type ResumeHeaderProps = {
+  data: Pick<ResumeData, "name" | "email" | "contact">;
+  issueDate: string;
+};
+
+export function ResumeHeader({ data, issueDate }: ResumeHeaderProps) {
+  return (
+    <header className="mb-10 pb-6 border-b border-border">
+      <h1 className="text-2xl font-semibold text-foreground">{data.name}</h1>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        <a
+          href={`mailto:${data.email}`}
+          className="hover:text-foreground underline-offset-2 hover:underline print:no-underline"
+        >
+          {data.email}
+        </a>
+        {data.contact ? <span>{data.contact}</span> : null}
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground">발급일: {issueDate}</p>
+    </header>
+  );
+}

--- a/features/resume/components/Section.tsx
+++ b/features/resume/components/Section.tsx
@@ -1,0 +1,15 @@
+type SectionProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function Section({ title, children }: SectionProps) {
+  return (
+    <section className="mb-8">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground border-b border-border pb-1">
+        {title}
+      </h2>
+      <div className="text-foreground">{children}</div>
+    </section>
+  );
+}

--- a/features/resume/data.ts
+++ b/features/resume/data.ts
@@ -1,0 +1,75 @@
+/**
+ * 이력서·경력증명서 하드코딩 데이터.
+ * DB/API 연동 없음.
+ */
+
+export type CareerItem = {
+  company: string;
+  period: string;
+  position: string;
+  duties: string[];
+};
+
+export type EducationItem = {
+  school: string;
+  period: string;
+  major: string;
+  degree: string;
+};
+
+export type CertificationItem = {
+  name: string;
+  issuer?: string;
+  date?: string;
+};
+
+export type ResumeData = {
+  name: string;
+  email: string;
+  contact?: string;
+  summary?: string;
+  career: CareerItem[];
+  education: EducationItem[];
+  skills: string[];
+  certifications: CertificationItem[];
+};
+export const resumeData: ResumeData = {
+  name: "이유정",
+  email: "idoasisy.yc@gmail.com",
+  contact: "010-0000-0000", // 실제 번호로 수정 필요
+  summary:
+    "0에서 1을 만드는 과정에서의 기술적 문제를 정의하고 해결하는 엔지니어입니다. 웹 서비스 기획부터 배포, 운영 프로세스 구축까지 전 과정을 주도적으로 수행하며 비즈니스 성장에 기여합니다.",
+  career: [
+    {
+      company: "AAC",
+      period: "2024.10 – 현재",
+      position: "Software Engineer",
+      duties: [
+        "신규 웹 서비스 아키텍처 설계 및 풀스택 개발 주도",
+        "서비스 확장을 위한 웹 보일러플레이트 구축 및 배포 자동화 파이프라인 수립",
+        "비즈니스 관점의 CRM(고객 관계 관리) 시스템 및 키오스크 인터페이스 설계/구현",
+        "초기 제품 릴리즈 및 안정화를 위한 지속적인 유지보수 및 기능 고도화",
+      ],
+    },
+    {
+      company: "Codestates",
+      period: "2019.09 – 2023.05",
+      position: "Technical Instructor & Developer",
+      duties: [
+        "CS 기초(알고리즘, 자료구조) 및 프론트엔드/백엔드 통합 커리큘럼 강의",
+        "블록체인 기술 원리 및 스마트 컨트랙트 활용 기술 교육",
+        "수강생의 기술적 성장을 위한 코드 리뷰 및 프로젝트 멘토링 수행",
+      ],
+    },
+  ],
+  education: [
+    {
+      school: "계원예술대학교",
+      period: "2014.03 – 2019.09",
+      major: "애니메이션학과",
+      degree: "학사",
+    },
+  ],
+  skills: ["TypeScript", "React", "Next.js", "Node.js", "PostgreSQL", "Flutter"],
+  certifications: [{ name: "직업능력개발훈련교사 자격 (정보통신 분야)", issuer: "고용노동부", date: "2019" }],
+};

--- a/features/resume/index.tsx
+++ b/features/resume/index.tsx
@@ -1,0 +1,1 @@
+export { ResumeView } from "./ResumeView";

--- a/features/resume/styles/resume.css
+++ b/features/resume/styles/resume.css
@@ -1,0 +1,16 @@
+/* Resume 페이지 전용 스타일 (인쇄 포함) */
+
+@media print {
+  .resume-page {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .resume-page a {
+    text-decoration: none;
+  }
+
+  .resume-page a[href^="mailto:"]::after {
+    content: none;
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,7 +9,14 @@ export function middleware(request: NextRequest) {
   const hostname = request.headers.get("host") || "";
 
   // 1. 서브도메인 판단 (로컬호스트 포함)
+  const isResumeSubdomain = hostname.startsWith("resume.");
   const isBlogSubdomain = hostname.startsWith("blog.");
+
+  if (isResumeSubdomain) {
+    // resume.xxx/... → 내부 /resume (단일 페이지)
+    url.pathname = "/resume";
+    return NextResponse.rewrite(url);
+  }
 
   if (isBlogSubdomain) {
     // [Case A] 서브도메인으로 접속했을 때 (blog.xxx/...)
@@ -32,6 +39,15 @@ export function middleware(request: NextRequest) {
     }
   } else {
     // [Case B] 메인 도메인으로 접속했을 때 (imio.dev/blog)
+
+    // 본 도메인 루트(/) → blog. 서브도메인으로 리다이렉트
+    if (pathname === "/") {
+      const redirectUrl = new URL(request.url);
+      redirectUrl.hostname = `blog.${redirectUrl.hostname}`;
+      redirectUrl.pathname = "/";
+      redirectUrl.search = "";
+      return NextResponse.redirect(redirectUrl, 307);
+    }
 
     // 기존 로직: /blog 접속 시 /blog/info로 리다이렉트
     const category = searchParams.get("category")?.trim();


### PR DESCRIPTION
- features/resume: 이력서 뷰, 데이터(하드코딩), 인쇄 스타일
- app/resume: 라우트, 헤더 없는 레이아웃
- middleware: resume. 서브도메인 → /resume rewrite
- middleware: 본 도메인 / → blog. 서브도메인 리다이렉트
- Header: Resume 링크 (NEXT_PUBLIC_RESUME_URL)

Made-with: Cursor